### PR TITLE
Modify copyright semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ as a general guide toward achieving the following goals:
    translate between schema that have been authorized by relevant parties;
 1. The provenance of Rights has to be made explicit;
 1. Any participant has the ability to make standardized, machine-readable statements about
-   rightholdings in creations;
+   rightholdings in Creations;
 1. Conflicts in rights declarations should be automatically identifiable; and
 1. Registered Creations have links to corresponding digital "fingerprints" or "watermarks".
 
@@ -1266,18 +1266,21 @@ Not only is the vocabulary of [schema.org/CreativeWork](http://schema.org/Creati
 quite extensive, there are also a number of subtypes that can be used to define specifics about a
 creation (e.g. [schema.org/Book](http://schema.org/Book)). However, one distinction to highlight is
 how an RRM Creation has two `CreationMode`s: one for perceivable Creations (called `Manifestation`s)
-and one for abstract Creations (called `Work`s). Transforming to JSON-LD, we get:
+and one for abstract Creations (called `Work`s). Note that in the rest of the text, we use
+`Creation` to refer to the entity type which encompasses both `Work`s and `Manifestation`s.
+
+Transforming to JSON-LD, we get:
 
 
 ```javascript
-// A Creation object and its Manifestations in JSON-LD
+// A Work and its Manifestations in JSON-LD
 // Note: We assume that the data will be put on an immutable ledger and so all links must point
 //       "backwards"
 {
     "@graph": [
         {
             "@id": "#creation",
-            "@type": "http://coalaip.schema/Creation",
+            "@type": "http://coalaip.schema/Work",
             "name": "Lord of the Rings",
             "author": "<URI pointing to the author Person>"
         },
@@ -1285,8 +1288,8 @@ and one for abstract Creations (called `Work`s). Transforming to JSON-LD, we get
             "@id": "#digitalManifestation",
             "@type": "http://coalaip.schema/Manifestation",
             "name": "The Fellowship of the Ring",
-            "creation": "#creation",
-            "digital_work": "<URI pointing to file>",
+            "manifestationOfWork": "#creation",
+            "digitalWork": "<URI pointing to file>",
             "fingerprints": [
                 "Qmbs2DxMBraF3U8F7vLAarGmZaSFry3vVY5zytuN3BxwaY",
                 "<multihash/fingerprint value>"
@@ -1297,7 +1300,7 @@ and one for abstract Creations (called `Work`s). Transforming to JSON-LD, we get
             "@id": "#physicalManifestation",
             "@type": "http://coalaip.schema/Manifestation",
             "name": "The Fellowship of the Ring",
-            "creation": "#creation",
+            "manifestationOfWork": "#creation",
             "datePublished": "29-07-1954",
             "locationCreated": "<URI pointing to a Place>"
         }
@@ -1311,19 +1314,19 @@ linked with hashes:
 
 
 ```javascript
-// A Creation object in IPLD
+// A Work object in IPLD
 {
-    "@type": { "/": "<hash pointing to RDF-Schema of Creation (can be any subtype of CreativeWork)>" },
+    "@type": { "/": "<hash pointing to RDF-Schema of Work>" },
     "name": "Lord of the Rings",
     "author": { "/": "<hash pointing to the author Person>" }
 }
 
-// A a digital Manifestation of the Creation in IPLD
+// A digital Manifestation of the Work in IPLD
 {
-    "@type": { "/": "<hash pointing to RDF-Schema of Manifestation>" },
+    "@type": { "/": "<hash pointing to RDF-Schema of Manifestation (can be any subtype of CreativeWork)>" },
     "name": "The Fellowship of the Ring",
-    "creation": { "/": "<hash pointing to the Creation>" },
-    "digital_work": { "/": "<hash pointing to a file on e.g. IPFS>" },
+    "manifestationOfWork": { "/": "<hash pointing to the Work>" },
+    "digitalWork": { "/": "<hash pointing to a file on e.g. IPFS>" },
     "fingerprints": [
         "Qmbs2DxMBraF3U8F7vLAarGmZaSFry3vVY5zytuN3BxwaY",
         "<multihash/fingerprint value>"
@@ -1331,22 +1334,23 @@ linked with hashes:
     "locationCreated": { "/": "<URI pointing to a Place>" }
 }
 
-// A a physical Manifestation of the Creation in IPLD
+// A physical Manifestation of the Work in IPLD
 {
     "@type": { "/": "<hash pointing to RDF-Schema of Manifestation>" },
     "name": "The Fellowship of the Ring",
-    "creation": { "/": "<hash pointing to the Creation>" },
+    "manifestationOfWork": { "/": "<hash pointing to the Work>" },
     "datePublished": "29-07-1954",
     "locationCreated": { "/": "<URI pointing to a Place>" }
 }
 ```
 
 
-Note that a distinction has been made between works (typed as `Creation`s)
+Note that a distinction has been made between works (typed as `Work`s)
 and manifestations (typed as `Manifestation`s). Both physical and digital manifestations can be
 represented, with digital manifestations including a set of fingerprints as well as a link pointing
-to an example of the work. In the future, we plan to subtype both a `Creation` and a
-`Manifestation` type from schema.org's CreativeWork to allow the easy addition of properties.
+to an example of the work. In the future, we plan to subtype both a `Work` and a
+`Manifestation` type from schema.org's `CreativeWork` to allow their properties to be easily
+customizable.
 
 
 #### The Copyright Transfer
@@ -1425,8 +1429,8 @@ distribute a Manifestation's Rights to a multitude of interested Parties must ta
 steps:
 
 1. Register their Party identifier on a global registry;
-1. Register their Creation on a global registry and link it to their Party identifier;
-1. Register Manifestations to the Creation on a global registry;
+1. Register their Creation as a Work on a global registry and link it to their Party identifier;
+1. Register Manifestations to the Work on a global registry;
 1. Register any number of Rights tailored to interested Parties on a global registry; and
 1. Register RightAssignments to assign these Rights to interested Parties.
 
@@ -1646,10 +1650,10 @@ but rather on a model's attributes and links.
 Think about the following scenario:
 
 > Andy Warhol decides to use the COALA IP protocol to register his work on a blockchain. He's
-  registering one of his works called "32 Campbell's Soup Cans" as a Creation and attaches a poster
+  registering one of his works called "32 Campbell's Soup Cans" as a Work and attaches a poster
   of the work as a Manifestation of it. He also creates a Right defining the licensing terms of
   buying the poster and attaches it to the Manifestation. Since Andy is not really good with
-  computers—they were never really his type of medium—he accidentally registers a Creation
+  computers—they were never really his type of medium—he accidentally registers a Work
   of Edvard Munch's "The Scream" under his name.
 
 Visually, this is what we'd end up with:
@@ -1663,7 +1667,7 @@ content-addressed storage. In contrast to a traditional SQL database, it is impo
 the transactions. We can only append to a blockchain. The solution is to append an Assertion
 validating specific statements that are true.
 
-Instead of falsifying the existence of the Creation "The Scream", the solution recommended by the
+Instead of falsifying the existence of the Work "The Scream", the solution recommended by the
 LCC RRM, COALA IP suggests making an Assertion about "The Scream"'s Author property. With IPLD's
 Merkle-path feature, we are able to achieve exactly that by defining an Assertion object:
 
@@ -1674,8 +1678,8 @@ Merkle-path feature, we are able to achieve exactly that by defining an Assertio
     "truth": "false",
     "asserter": { "/": "<hash pointing to a Party>" },
     "subject": {
-        "/": "<IPLD hash pointing to Creation: The Scream's author property>"
-        // e.g. /ipdb/<hash_of_creation>/author
+        "/": "<IPLD hash pointing to Work: The Scream's author property>"
+        // e.g. /ipdb/<hash of work>/author
     }
 }
 
@@ -1686,7 +1690,7 @@ Merkle-path feature, we are able to achieve exactly that by defining an Assertio
     "truth": "true",
     "asserter": { "/": "<hash pointing to a Party>" },
     "subject": {
-        "/": "<IPLD hash pointing to Creation: 32 Campbell's Soup Cans's author property>"
+        "/": "<IPLD hash pointing to Work: 32 Campbell's Soup Cans's author property>"
     }
 }
 ```

--- a/data-structure/README.md
+++ b/data-structure/README.md
@@ -255,7 +255,8 @@ an `manifestationOfWork` (equivalent to [`exampleOfWork`](http://schema.org/exam
 as a `Work` and all other CreativeWorks (or subtypes) as `Manifestation`s. `Manifestation`s that
 include a [`url`](http://schema.org/url) property are considered digital `Manifestation`s while all
 others are physical `Manifestation`s. See the [schema.org/CreativeWork definition](http://schema.org/CreativeWork)
-for the Linked Data context.
+for the Linked Data context. Note that, elsewhere in the text, we use `Creation` to encompass both
+`Work`s and `Manifestation`s.
 
 The `manifestationOfWork` property definition:
 

--- a/data-structure/README.md
+++ b/data-structure/README.md
@@ -466,7 +466,10 @@ An example of adding fingerprinting information for a digital `Manifestation`:
 ```javascript
 // In JSON-LD
 {
-    "@context": "<coalaip placeholder>",
+    "@context": [
+        "http://schema.org/",
+        "<coalaip placeholder>"
+    ],
     "@type": "DigitalFingerprint",
     "@id": "<URI pointing to this object>",
     "fingerprintOf": "<URI pointing to a CreativeWork object or media blob>",
@@ -475,7 +478,10 @@ An example of adding fingerprinting information for a digital `Manifestation`:
 
 // In IPLD
 {
-    "@context": { "/": "<hash pointing to COALA IP's context>" }, // For now, these could also be a URI to the context
+    "@context": [ // For now, these could also be a URI to the context
+        { "/": "<hash pointing to schema.org's context>" },
+        { "/": "<hash pointing to COALA IP's context>" }
+    ],
     "@type": "DigitalFingerprint",
     "fingerprintOf": "<hash pointing to a CreativeWork object or media blob>",
     "fingerprint": "Qmbs2DxMBraF3U8F7vLAarGmZaSFry3vVY5zytuN3BxwaY"
@@ -668,7 +674,7 @@ An example of a `Right`:
 {
     "@context": [
         "http://schema.org/",
-        <coalaip placeholder>
+        "<coalaip placeholder>"
     ],
     "@type": "<coalaip placeholder>/Right",
     "@id": "<URI pointing to this object>",
@@ -749,7 +755,10 @@ An example of an `RightsAssignment` payload:
 ```javascript
 // In JSON-LD
 {
-    "@context": <coalaip placeholder>,
+    "@context": [
+        "http://schema.org/",
+        "<coalaip placeholder>"
+    ],
     "@id": "<URI pointing to this object>",
     "@type": "RightsTransferAction",
     "transferContract": [
@@ -762,7 +771,10 @@ An example of an `RightsAssignment` payload:
 
 // In IPLD
 {
-    "@context": { "/": "<hash pointing to COALA IP's context>" }, // For now, these could also be a URI to the context
+    "@context": [ // For now, these could also be a URI to the context
+        { "/": "<hash pointing to schema.org's context>" },
+        { "/": "<hash pointing to COALA IP's context>" }
+    ],
     "@type": "RightsTransferAction",
     "transferContract": [
         { "/": "<hash pointing to a CreativeWork object or file on e.g. IPFS>" },

--- a/data-structure/README.md
+++ b/data-structure/README.md
@@ -777,8 +777,9 @@ An example of an `RightsAssignment` payload:
 
 - `transferContract` is defined to be of type `"@id"` for ease of use with URLs. A string value can
   be added by using an expanded property containing `"@value"`.
-- In the context of transferring rights through a ledger, the `object`, `agent`, and `participant`
-  properties are unnecessary as they are already implicitly defined in the containing transaction.
+- In the context of transferring rights through a ledger, the `object`, `agent`, `participant`,
+  `endTime`, and `startTime` properties are unnecessary as they are already implicitly defined in
+  the containing transaction.
 
 ### RRM Assertion
 

--- a/data-structure/README.md
+++ b/data-structure/README.md
@@ -281,7 +281,7 @@ An example of a `Work`, and its physical and digital `Manifestation`s:
 //       E.g. The Work is registered first and then the Manifestations are linked back to the Work.
 
 // In JSON-LD
-// Creation
+// Work
 {
     "@context": [
         "http://schema.org/",
@@ -289,7 +289,8 @@ An example of a `Work`, and its physical and digital `Manifestation`s:
     ],
     "@type": "CreativeWork",
     "@id": "<URI pointing to this object>",
-    "name": "Lord of the Rings"
+    "name": "Lord of the Rings",
+    "creator": "<URI pointing to a Person or Organization object>"
 }
 
 // Digital Manifestation
@@ -328,14 +329,15 @@ An example of a `Work`, and its physical and digital `Manifestation`s:
 }
 
 // In IPLD
-// Creation
+// Work
 {
     "@context": [ // For now, these could also be a URI to the context
         { "/": "<hash pointing to schema.org's context>" },
         { "/": "<hash pointing to COALA IP's context>" }
     ],
     "@type": "CreativeWork",
-    "name": "Lord of the Rings"
+    "name": "Lord of the Rings",
+    "creator": { "/": "<hash pointing to a Person or Organization object>" },
 }
 
 // Digital Manifestation

--- a/data-structure/README.md
+++ b/data-structure/README.md
@@ -495,18 +495,8 @@ with the following vocabulary:
     "rdfs:subClassOf": {
         "@id": "schema:Intangible"
     },
-    ...
-}
-
-// Creation Property
-{
-    "@id": "<coalaip placeholder>/creation",
-    "@type": "rdf:Property",
-    "schema:domainIncludes": {
-        "@id": "coala:Right"
-    },
-    "schema:rangeIncludes": {
-        "@id": "schema:CreativeWork"
+    "owl:equivalentClass": {
+        "@id": "dc:RightsStatement"
     },
     ...
 }
@@ -559,6 +549,22 @@ with the following vocabulary:
     },
     "schema:rangeIncludes": {
         "@id": "schema:Text"
+    },
+    ...
+}
+
+// RightsOf Property
+{
+    "@id": "<coalaip placeholder>/rightsOf",
+    "@type": "rdf:Property",
+    "schema:domainIncludes": {
+        "@id": "coala:Right"
+    },
+    "schema:rangeIncludes": {
+        "@id": "schema:CreativeWork"
+    },
+    "owl:equivalentProperty": {
+        "@id": "dc:rights"
     },
     ...
 }
@@ -652,6 +658,8 @@ with the following vocabulary:
 - `percentageShares` must be a number between 0 and 100.
 - `rightContext` and `usageType` contain arbitrary strings that should be classified by the
   registrar of the `Right`
+- `schema.org/license` can be used to provide a URL to the legal license document covering this
+  `Right`
 
 An example of a `Right`:
 
@@ -672,7 +680,7 @@ An example of a `Right`:
     "percentageShares": 30,
     "validFrom": "2016-01-01",
     "validThrough": "2016-02-01",
-    "creation": "<URI pointing to a CreativeWork object (that should be a Manifestation)>",
+    "rightsOf": "<URI pointing to a CreativeWork object (that should be a Manifestation)>",
     "license": "<URI pointing to a CreativeWork object or file (ideally on an immutable ledger)>" // Uses schema.org/license property
 }
 
@@ -691,7 +699,7 @@ An example of a `Right`:
     "percentageShares": 30,
     "validFrom": "2016-01-01",
     "validThrough": "2016-02-01",
-    "creation": { "/": "<hash pointing to a CreativeWork object (that should be a Manifestation)>" },
+    "rightsOf": { "/": "<hash pointing to a CreativeWork object (that should be a Manifestation)>" },
     "license": { "/": "<hash pointing to a CreativeWork object or file on e.g. IPFS>" } // Uses schema.org/license property
 }
 ```

--- a/data-structure/README.md
+++ b/data-structure/README.md
@@ -289,8 +289,7 @@ An example of a `Work`, and its physical and digital `Manifestation`s:
     ],
     "@type": "CreativeWork",
     "@id": "<URI pointing to this object>",
-    "name": "Lord of the Rings",
-    "author": "<URI pointing to a Person or Organization object>"
+    "name": "Lord of the Rings"
 }
 
 // Digital Manifestation
@@ -305,6 +304,7 @@ An example of a `Work`, and its physical and digital `Manifestation`s:
     "exampleOfWork": "<URI pointing to a CreativeWork object>",
     "isManifestation": true,
     "isPartOf" "<URI pointing to a CreativeWork object>",
+    "author": "<URI pointing to a Person or Organization object>",
     "datePublished": "29-07-1954",
     "locationCreated": "<URI pointing to a Place object>",
     "url": "<URI pointing to digital representation>"
@@ -322,6 +322,7 @@ An example of a `Work`, and its physical and digital `Manifestation`s:
     "exampleOfWork": "<URI pointing to a CreativeWork object>",
     "isManifestation": true,
     "isPartOf" "<URI pointing to a CreativeWork object>",
+    "author": "<URI pointing to a Person or Organization object>",
     "datePublished": "29-07-1954",
     "locationCreated": "<URI pointing to a Place object>"
 }
@@ -334,8 +335,7 @@ An example of a `Work`, and its physical and digital `Manifestation`s:
         { "/": "<hash pointing to COALA IP's context>" }
     ],
     "@type": "CreativeWork",
-    "name": "Lord of the Rings",
-    "author": { "/": "<hash pointing to a Person or Organization object>" }
+    "name": "Lord of the Rings"
 }
 
 // Digital Manifestation
@@ -349,6 +349,7 @@ An example of a `Work`, and its physical and digital `Manifestation`s:
     "exampleOfWork": { "/": "<hash pointing to a CreativeWork object>" },
     "isManifestation": true,
     "isPartOf" { "/": "<hash pointing to a CreativeWork object>" },
+    "author": { "/": "<hash pointing to a Person or Organization object>" },
     "datePublished": "29-07-1954",
     "locationCreated": { "/": "<hash pointing to a Place object>" },
     "url": { "/": "<hash pointing to a file on e.g. IPFS>" }
@@ -365,6 +366,7 @@ An example of a `Work`, and its physical and digital `Manifestation`s:
     "exampleOfWork": { "/": "<hash pointing to a CreativeWork object>" },
     "isManifestation": true,
     "isPartOf" { "/": "<hash pointing to a CreativeWork object>" },
+    "author": { "/": "<hash pointing to a Person or Organization object>" },
     "datePublished": "29-07-1954",
     "locationCreated": { "/": "<hash pointing to a Place object>" },
     "url": { "/": "<hash pointing to a file on e.g. IPFS>" }

--- a/data-structure/README.md
+++ b/data-structure/README.md
@@ -76,10 +76,10 @@ Adhering to these patterns helps you to avoid the creation of models that are to
 an immutable context. For example, consider the [`Creation`](#rrm-creation) entity: although the
 schema allows a `Work` to declare its manifestations through the [workExample property](http://schema.org/workExample),
 doing so would inherently lock the `Work` into only these `Manifestation`s. You can avoid this
-problem by declaring your `Work`s and `Manifestation`s separately, using the [exampleOfWork
-property](http://schema.org/exampleOfWork) in the `Manifestation`s to create a link to its `Work`.
-Another feature of this pattern is that you only have to declare a nested model once, even if
-multiple parents should be linked to it.
+problem by declaring your `Work`s and `Manifestation`s separately, using the [`manifestationOfWork`
+property](#rrm-creation) (alias of [`exampleOfWork`](http://schema.org/exampleOfWork)) in the
+`Manifestation`s to create a link to its `Work`. Another feature of this pattern is that you only
+have to declare a nested model once, even if multiple parents should be linked to it.
 
 When relying on inter-object links rather than nested objects, you may find that some properties
 from schema.org expect an object or value rather than a link. To handle this, you can either use an
@@ -251,11 +251,30 @@ An example of a localizable `Place`:
 `Creation`s are represented by [schema.org/CreativeWork](http://schema.org/CreativeWork)s and its
 subtypes (such as [schema.org/Book](http://schema.org/Book)). To differentiate between the different
 `CreationMode`s (`lcc:Manifestation` or `lcc:Work`), we treat any CreativeWork that does not contain
-an [`exampleOfWork`](http://schema.org/exampleOfWork) property as a `Work` and all other
-CreativeWorks (or subtypes) as `Manifestation`s. `Manifestation`s that include a [`url`](http://schema.org/url)
-property are considered digital `Manifestation`s while all others are physical `Manifestation`s. See
-the [schema.org/CreativeWork definition](http://schema.org/CreativeWork) for the Linked Data
-context.
+an `manifestationOfWork` (equivalent to [`exampleOfWork`](http://schema.org/exampleOfWork)) property
+as a `Work` and all other CreativeWorks (or subtypes) as `Manifestation`s. `Manifestation`s that
+include a [`url`](http://schema.org/url) property are considered digital `Manifestation`s while all
+others are physical `Manifestation`s. See the [schema.org/CreativeWork definition](http://schema.org/CreativeWork)
+for the Linked Data context.
+
+The `manifestationOfWork` property definition:
+
+```javascript
+{
+    "@id": "<coalaip placeholder>/manifestationOfWork",
+    "@type": "rdf:Property",
+    "schema:domainIncludes": {
+        "@id": "schema:CreativeWork"
+    },
+    "schema:rangeIncludes": {
+        "@id": "schema:CreativeWork"
+    },
+    "owl:equivalentProperty": {
+        "@id": "schema:exampleOfWork"
+    },
+    ...
+}
+```
 
 To conveniently identify `Manifestation`s, we also suggest adding a `isManifestation` property
 (*although this is not mandatory*):
@@ -302,7 +321,7 @@ An example of a `Work`, and its physical and digital `Manifestation`s:
     "@type": "Book",
     "@id": "<URI pointing to this object>",
     "name": "The Fellowship of the Ring",
-    "exampleOfWork": "<URI pointing to a CreativeWork object>",
+    "manifestationOfWork": "<URI pointing to a CreativeWork object>",
     "isManifestation": true,
     "isPartOf" "<URI pointing to a CreativeWork object>",
     "author": "<URI pointing to a Person or Organization object>",
@@ -320,7 +339,7 @@ An example of a `Work`, and its physical and digital `Manifestation`s:
     "@type": "Book",
     "@id": "<URI pointing to this object>",
     "name": "The Fellowship of the Ring",
-    "exampleOfWork": "<URI pointing to a CreativeWork object>",
+    "manifestationOfWork": "<URI pointing to a CreativeWork object>",
     "isManifestation": true,
     "isPartOf" "<URI pointing to a CreativeWork object>",
     "author": "<URI pointing to a Person or Organization object>",
@@ -348,7 +367,7 @@ An example of a `Work`, and its physical and digital `Manifestation`s:
     ],
     "@type": "Book",
     "name": "The Fellowship of the Ring",
-    "exampleOfWork": { "/": "<hash pointing to a CreativeWork object>" },
+    "manifestationOfWork": { "/": "<hash pointing to a CreativeWork object>" },
     "isManifestation": true,
     "isPartOf" { "/": "<hash pointing to a CreativeWork object>" },
     "author": { "/": "<hash pointing to a Person or Organization object>" },
@@ -365,7 +384,7 @@ An example of a `Work`, and its physical and digital `Manifestation`s:
     ],
     "@type": "Book",
     "name": "The Fellowship of the Ring",
-    "exampleOfWork": { "/": "<hash pointing to a CreativeWork object>" },
+    "manifestationOfWork": { "/": "<hash pointing to a CreativeWork object>" },
     "isManifestation": true,
     "isPartOf" { "/": "<hash pointing to a CreativeWork object>" },
     "author": { "/": "<hash pointing to a Person or Organization object>" },

--- a/data-structure/coala_context.json
+++ b/data-structure/coala_context.json
@@ -22,10 +22,6 @@
             "@type": "@id"
         },
         "assertionTruth": "coala:assertionTruth",
-        "creation": {
-            "@id": "coala:creation",
-            "@type": "@id"
-        },
         "exclusive": "coala:exclusive",
         "fingerprintOf": {
             "@id": "coala:fingerprintOf",
@@ -40,6 +36,10 @@
         "numberOfUses": "coala:numberOfUses",
         "percentageShares": "coala:percentageShares",
         "rightContext": "coala:rightContext",
+        "rightsOf": {
+            "@id": "coala:rightsOf",
+            "@type": "@id"
+        },
         "territory": {
             "@id": "coala:territory",
             "@type": "@id"

--- a/data-structure/coala_context.json
+++ b/data-structure/coala_context.json
@@ -9,10 +9,15 @@
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
         "schema": "http://schema.org/",
 
+        "Copyright": "coala:Copyright",
         "DigitalFingerprint": "coala:DigitalFingerprint",
         "Right": "coala:Right",
         "RightsTransferAction": "coala:RightsTransferAction",
 
+        "allowedBy": {
+            "@id": "coala:allowedBy",
+            "@type": "@id"
+        },
         "asserter": {
             "@id": "coala:asserter",
             "@type": "@id"

--- a/data-structure/coala_context.json
+++ b/data-structure/coala_context.json
@@ -33,6 +33,10 @@
         },
         "fingerprint": "coala:fingerprint",
         "isManifestation": "coala:isManifestation",
+        "manifestationOfWork": {
+            "@id": "coala:manifestationOfWork",
+            "@type": "@id"
+        },
         "numberOfUses": "coala:numberOfUses",
         "percentageShares": "coala:percentageShares",
         "rightContext": "coala:rightContext",
@@ -50,10 +54,6 @@
 
         "author": {
             "@id": "schema:author",
-            "@type": "@id"
-        },
-        "exampleOfWork": {
-            "@id": "schema:exampleOfWork",
             "@type": "@id"
         },
         "founder": {

--- a/data-structure/vocab/coala.jsonld
+++ b/data-structure/vocab/coala.jsonld
@@ -1,5 +1,6 @@
 {
     "@context": {
+        "coala": "<coalaip placeholder>",
         "dc": "http://purl.org/dc/terms/",
         "owl": "http://www.w3.org/2002/07/owl#",
         "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
@@ -15,6 +16,18 @@
             },
             "rdfs:comment": "Generic digital fingerprint for a Creation.",
             "rdfs:label": "DigitalFingerprint"
+        },
+        {
+            "@id": "<coalaip placeholder>/Copyright",
+            "@type": "rdfs:Class",
+            "rdfs:subClassOf": {
+                "@id": "schema:Intangible"
+            },
+            "owl:equivalentClass": {
+                "@id": "dc:RightsStatement"
+            },
+            "rdfs:comment": "Describes the full copyright for a Creation.",
+            "rdfs:label": "Copyright"
         },
         {
             "@id": "<coalaip placeholder>/Right",
@@ -36,6 +49,21 @@
             },
             "rdfs:comment": "A transfer of Rights from one Party (or more) to another Party (or more).",
             "rdfs:label": "RightsTransferAction"
+        },
+        {
+            "@id": "<coalaip placeholder>/allowedBy",
+            "@type": "rdf:Property",
+            "schema:domainIncludes": {
+                "@id": "coala:Right"
+            },
+            "schema:rangeIncludes": {
+                "@id": "schema:Copyright"
+            },
+            "owl:equivalentProperty": {
+                "@id": "dc:source"
+            },
+            "rdfs:comment": "The object upon which another object was allowed By. For example, the souurce Copyright upon which a narrower Right was derived from.",
+            "rdfs:label": "allowedBy"
         },
         {
             "@id": "<coalaip placeholder>/asserter",
@@ -201,7 +229,7 @@
             "@id": "<coalaip placeholder>/rightsOf",
             "@type": "rdf:Property",
             "schema:domainIncludes": {
-                "@id": "coala:Right"
+                "@id": "coala:Copyright"
             },
             "schema:rangeIncludes": {
                 "@id": "schema:CreativeWork"
@@ -209,15 +237,20 @@
             "owl:equivalentProperty": {
                 "@id": "dc:rights"
             },
-            "rdfs:comment": "The object upon which a Right is concerned with.",
+            "rdfs:comment": "The creation upon which a Copyright is concerned with.",
             "rdfs:label": "rightsOf"
         },
         {
             "@id": "<coalaip placeholder>/territory",
             "@type": "rdf:Property",
-            "schema:domainIncludes": {
-                "@id": "coala:Right"
-            },
+            "schema:domainIncludes": [
+                {
+                    "@id": "coala:Copyright"
+                },
+                {
+                    "@id": "coala:Right"
+                }
+            ],
             "schema:rangeIncludes": {
                 "@id": "schema:Place"
             },
@@ -264,6 +297,9 @@
             "@type": "rdf:Property",
             "schema:domainIncludes": [
                 {
+                    "@id": "coala:Copyright"
+                },
+                {
                     "@id": "coala:Right"
                 },
                 {
@@ -288,6 +324,9 @@
             "@id": "<coalaip placeholder>/validThrough",
             "@type": "rdf:Property",
             "schema:domainIncludes": [
+                {
+                    "@id": "coala:Copyright"
+                },
                 {
                     "@id": "coala:Right"
                 },

--- a/data-structure/vocab/coala.jsonld
+++ b/data-structure/vocab/coala.jsonld
@@ -237,7 +237,7 @@
             "owl:equivalentProperty": {
                 "@id": "dc:rights"
             },
-            "rdfs:comment": "The creation upon which a Copyright is concerned with.",
+            "rdfs:comment": "The Creation upon which a Copyright is concerned with.",
             "rdfs:label": "rightsOf"
         },
         {

--- a/data-structure/vocab/coala.jsonld
+++ b/data-structure/vocab/coala.jsonld
@@ -1,5 +1,6 @@
 {
     "@context": {
+        "dc": "http://purl.org/dc/terms/",
         "owl": "http://www.w3.org/2002/07/owl#",
         "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
         "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
@@ -20,6 +21,9 @@
             "@type": "rdfs:Class",
             "rdfs:subClassOf": {
                 "@id": "schema:Intangible"
+            },
+            "owl:equivalentClass": {
+                "@id": "dc:RightsStatement"
             },
             "rdfs:comment": "Describes a state in which a Party is entitled to do something in relation to a Creation.",
             "rdfs:label": "Right"
@@ -77,18 +81,6 @@
             },
             "rdfs:comment": "The truth claim made about an assertion's subject.",
             "rdfs:label": "assertionTruth"
-        },
-        {
-            "@id": "<coalaip placeholder>/creation",
-            "@type": "rdf:Property",
-            "schema:domainIncludes": {
-                "@id": "coala:Right"
-            },
-            "schema:rangeIncludes": {
-                "@id": "schema:CreativeWork"
-            },
-            "rdfs:comment": "The Creation associated with a Class in some way. For example, the Creation that a Right is bound to.",
-            "rdfs:label": "creation"
         },
         {
             "@id": "<coalaip placeholder>/exclusive",
@@ -204,6 +196,21 @@
             },
             "rdfs:comment": "The context in which a Right may be exercised. User defined.",
             "rdfs:label": "rightContext"
+        },
+        {
+            "@id": "<coalaip placeholder>/rightsOf",
+            "@type": "rdf:Property",
+            "schema:domainIncludes": {
+                "@id": "coala:Right"
+            },
+            "schema:rangeIncludes": {
+                "@id": "schema:CreativeWork"
+            },
+            "owl:equivalentProperty": {
+                "@id": "dc:rights"
+            },
+            "rdfs:comment": "The object upon which a Right is concerned with.",
+            "rdfs:label": "rightsOf"
         },
         {
             "@id": "<coalaip placeholder>/territory",

--- a/data-structure/vocab/coala.jsonld
+++ b/data-structure/vocab/coala.jsonld
@@ -155,6 +155,21 @@
             "rdfs:label": "isManifestation"
         },
         {
+            "@id": "<coalaip placeholder>/manifestationOfWork",
+            "@type": "rdf:Property",
+            "schema:domainIncludes": {
+                "@id": "schema:CreativeWork"
+            },
+            "schema:rangeIncludes": {
+                "@id": "schema:CreativeWork"
+            },
+            "owl:equivalentProperty": {
+                "@id": "schema:exampleOfWork"
+            },
+            "rdfs:comment": "The parent Work of this Manifestation.",
+            "rdfs:label": "manifestationOfWork"
+        },
+        {
             "@id": "<coalaip placeholder>/numberOfUses",
             "@type": "rdf:Property",
             "schema:domainIncludes": {


### PR DESCRIPTION
Upgrades the schemas for the current implementation, as discussed previously.

Notes:
- Aliased `exampleOfWork` with `manifestationOf` for clarity
- Added `Copyright` class in addition to `Right`; not subclassed directly from `Right` as I didn't want `Copyright`s to contain all the properties of `Right`. Perhaps sharing a common base class is better, especially if we would like the two to be "connected" via typing; not sure what we'd call this common base class though

Includes a few broken links until the spec is finished with its edits and updates.
