### PR TITLE
Add Copyright semantics and support lcc:SourceRights

### DIFF
--- a/data-structure/README.md
+++ b/data-structure/README.md
@@ -514,22 +514,6 @@ As no existing schema.org vocabulary fits the RRM's notion of a `Right` or [COAL
     ...
 }
 
-// AllowedBy Property
-{
-    "@id": "<coalaip placeholder>/allowedBy",
-    "@type": "rdf:Property",
-    "schema:domainIncludes": {
-        "@id": "coala:Right"
-    },
-    "schema:rangeIncludes": {
-        "@id": "coala:Copyright"
-    },
-    "owl:equivalentProperty": {
-        "@id": "dc:source"
-    },
-    ...
-}
-
 // Exclusive Property
 {
     "@id": "<coalaip placeholder>/exclusive",
@@ -594,6 +578,22 @@ As no existing schema.org vocabulary fits the RRM's notion of a `Right` or [COAL
     },
     "owl:equivalentProperty": {
         "@id": "dc:rights"
+    },
+    ...
+}
+
+// Source Property
+{
+    "@id": "<coalaip placeholder>/source",
+    "@type": "rdf:Property",
+    "schema:domainIncludes": {
+        "@id": "coala:Right"
+    },
+    "schema:rangeIncludes": {
+        "@id": "coala:Copyright"
+    },
+    "owl:equivalentProperty": {
+        "@id": "dc:source"
     },
     ...
 }
@@ -729,7 +729,7 @@ An example of a `Copyright` and a derived `Right`:
     ],
     "@type": "<coalaip placeholder>/Right",
     "@id": "<URI pointing to this object>",
-    "allowedBy": "<URI pointing to a Copyright object>",
+    "source": "<URI pointing to a Copyright object>",
     "usageType": ["all", "copy", "play"],
     "territory": "<URI pointing to a Place object>",
     "rightContext": ["inflight", "inpublic", "commercialuse"],
@@ -762,7 +762,7 @@ An example of a `Copyright` and a derived `Right`:
         { "/": "<hash pointing to COALA IP's context>" }
     ],
     "@type": "<coalaip placeholder>/Right",
-    "allowedBy": { "/": "<hash pointing to a Copyright object>" },
+    "source": { "/": "<hash pointing to a Copyright object>" },
     "usageType": ["all", "copy", "play"],
     "territory": { "/": "<hash pointing to a Place object>" },
     "rightContext": ["inflight", "inpublic", "commercialuse"],

--- a/data-structure/coala_context.json
+++ b/data-structure/coala_context.json
@@ -15,10 +15,6 @@
         "Right": "coala:Right",
         "RightsTransferAction": "coala:RightsTransferAction",
 
-        "allowedBy": {
-            "@id": "coala:allowedBy",
-            "@type": "@id"
-        },
         "asserter": {
             "@id": "coala:asserter",
             "@type": "@id"
@@ -43,6 +39,10 @@
         "rightContext": "coala:rightContext",
         "rightsOf": {
             "@id": "coala:rightsOf",
+            "@type": "@id"
+        },
+        "source": {
+            "@id": "coala:source",
             "@type": "@id"
         },
         "territory": {

--- a/data-structure/vocab/coala.jsonld
+++ b/data-structure/vocab/coala.jsonld
@@ -60,7 +60,7 @@
             "rdfs:label": "RightsTransferAction"
         },
         {
-            "@id": "<coalaip placeholder>/allowedBy",
+            "@id": "<coalaip placeholder>/source",
             "@type": "rdf:Property",
             "schema:domainIncludes": {
                 "@id": "coala:Right"
@@ -71,8 +71,8 @@
             "owl:equivalentProperty": {
                 "@id": "dc:source"
             },
-            "rdfs:comment": "The object upon which another object was allowed By. For example, the souurce Copyright upon which a narrower Right was derived from.",
-            "rdfs:label": "allowedBy"
+            "rdfs:comment": "The source object upon which another object was derived from. For example, the source Copyright upon which a narrower Right was allowed by.",
+            "rdfs:label": "source"
         },
         {
             "@id": "<coalaip placeholder>/asserter",


### PR DESCRIPTION
Moves the section on ownership semantics to be after Copyrights.

[Pretty diff](https://github.com/COALAIP/specs/pull/15/files?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8).